### PR TITLE
Add nixpacks.toml configuration for application startup

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,2 @@
+[phases.start]
+cmd = "uvicorn main:app --host 0.0.0.0 --port $PORT"


### PR DESCRIPTION
This pull request introduces a configuration change to the `nixpacks.toml` file to define the start command for the application.

- Application startup configuration:
  * Added a `[phases.start]` section with a `cmd` to launch the app using `uvicorn` and bind it to all interfaces and the specified port.