### PR TITLE
Add Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: uvicorn main:app --host 0.0.0.0 --port 8000


### PR DESCRIPTION
This pull request adds a `Procfile` to the project, specifying how to run the web application using Uvicorn. This will help with deployment to platforms that use `Procfile` conventions, such as Heroku.

- Deployment configuration:
  * Added a `Procfile` with a command to start the app using `uvicorn` (`web: uvicorn main:app --host 0.0.0.0 --port 8000`).